### PR TITLE
Add precommit hooks for dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,10 @@ Contributions are welcome. Please fork the repository and open a pull request in
 
 3) Install the project
 ```
-pip install -e .
+$ pip install -e .
+```
+
+4) (Optional) You may install pre-commit hooks to run static checks on-commit:
+```
+$ lefthook install
 ```

--- a/bin/static_checks.sh
+++ b/bin/static_checks.sh
@@ -1,2 +1,0 @@
-mypy .
-ruff check

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-push:
+  parallel: true
+
+pre-commit:
+  commands:
+    mypy-check:
+      glob: "*.{py}"
+      run: mypy {staged_files}
+    ruff-check:
+      glob: "*.{py}"
+      run: ruff check {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,4 +8,4 @@ pre-commit:
       run: mypy {staged_files}
     ruff-check:
       glob: "*.{py}"
-      run: ruff check {staged_files}
+      run: ruff check --fix {staged_files}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "ruff",
     "pytest",
     "aenum",
+    "lefthook"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
These hooks should execute static checks only python files staged for commit. 

Closes #10