### PR TITLE
Resolve mypy errors on default branch

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -3,8 +3,8 @@ name: Static Checks
 on: pull_request
 
 jobs:
-  mypy:
-    name: mypy
+  static-checks:
+    name: static-checks
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,9 +3,9 @@ name: Run Unit Tests
 on: pull_request
 
 jobs:
-  test:
+  pytest:
+    name: pytest
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version:

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -76,7 +76,7 @@ class Rank(Enum):
         }
         return int_to_rank_map[int_rank]
 
-    def __deepcopy__(self, memo: Any) -> "Rank":
+    def __deepcopy__(self, memo) -> "Rank":
         # Return the same enum instance—skip deepcopy
         return self
 

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -76,7 +76,7 @@ class Rank(Enum):
         }
         return int_to_rank_map[int_rank]
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Any) -> "Rank":
         # Return the same enum instance—skip deepcopy
         return self
 

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -76,7 +76,7 @@ class Rank(Enum):
         }
         return int_to_rank_map[int_rank]
 
-    def __deepcopy__(self, memo) -> "Rank":
+    def __deepcopy__(self, memo: Any) -> "Rank":
         # Return the same enum instance—skip deepcopy
         return self
 


### PR DESCRIPTION
Primarily, this tests branch protections (see [8d12297](https://github.com/maxsvetlik/balatro-gym/pull/20/commits/8d12297e84d1ec72f4e7b97bd9baf159d7a5796a) in which GH correctly prevented merging due to failed tests).

Otherwise:
- Fixes mypy error on `main`
- Gives more intuitive names to the GHA jobs, which is what is shown on the UI

Closes #7
