### PR TITLE
Add card interface tests

### DIFF
--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -137,12 +137,13 @@ class WildCard(Enhancement):
 
 class GlassCard(Enhancement):
     def get_multiplication(self) -> float:
+        # When scored
         return 2.0
 
 
 class SteelCard(Enhancement):
     def get_multiplication(self) -> float:
-        # TODO : When card is in hand
+        # When card is in hand
         return 1.5
 
 
@@ -165,12 +166,12 @@ class LuckyCard(Enhancement):
     _base_money_probability = 1 / 15
 
     def get_mult(self, probability_modifier: int = 1) -> int:
-        if np.random.random() <= self._base_mult_probability * probability_modifier:
+        if np.random.random() <= min(self._base_mult_probability * probability_modifier, 1):
             return 20
         return 0
 
     def get_scored_money(self, probability_modifier: int = 1) -> int:
-        if np.random.random() <= self._base_money_probability * probability_modifier:
+        if np.random.random() <= min(self._base_money_probability * probability_modifier, 1):
             return 20
         return 0
 
@@ -269,9 +270,9 @@ class PlayingCard(HasChips):
             return self.enhancement.get_mult()
         return 0
 
-    def get_multiplication(self) -> int:
+    def get_multiplication(self) -> float:
         if isinstance(self.enhancement, HasMultiplier):
-            return int(self.enhancement.get_multiplication())
+            return self.enhancement.get_multiplication()
         return 1
 
     def get_scored_money(self) -> int:

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -262,6 +262,8 @@ class PlayingCard(HasChips):
     def get_chips(self) -> int:
         enhancement_chips = 0
         if self._enhancement:
+            if isinstance(self._enhancement, StoneCard):
+                return 50
             enhancement_chips += self._enhancement.get_chips()
         return self._base_chips + self._added_chips + enhancement_chips
 

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -161,8 +161,8 @@ class GoldCard(Enhancement):
 
 
 class LuckyCard(Enhancement):
-    _base_mult_probability = 0.25
-    _base_money_probability = 0.0666666
+    _base_mult_probability = 1 / 5
+    _base_money_probability = 1 / 15
 
     def get_mult(self, probability_modifier: int = 1) -> int:
         if np.random.random() <= self._base_mult_probability * probability_modifier:
@@ -273,6 +273,16 @@ class PlayingCard(HasChips):
         if isinstance(self.enhancement, HasMultiplier):
             return int(self.enhancement.get_multiplication())
         return 1
+
+    def get_scored_money(self) -> int:
+        if isinstance(self.enhancement, HasMoney):
+            return self.enhancement.get_scored_money()
+        return 0
+
+    def get_end_money(self) -> int:
+        if isinstance(self.enhancement, HasMoney):
+            return self.enhancement.get_end_money()
+        return 0
 
     def set_enhancement(self, enhancement: Optional[Enhancement]) -> None:
         self._enhancement = enhancement

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -331,7 +331,6 @@ class PlayingCard(HasChips):
         )
 
 
-
 class Deck(HasReset):
     _cards_remaining: deque[PlayingCard]
     _cards_played: deque[PlayingCard]

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -91,12 +91,18 @@ def _get_flush(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
         if card.enhancement is not None:
             counter.update(card.enhancement.get_suit(card))
         else:
-            counter.update([card.suit])
+            counter.update(card.suit)
 
-    common_suit, count = counter.most_common(1)[0]
+    most_common_tup = counter.most_common(1)
+    count = 0
+    if len(most_common_tup) > 0:
+        # In some situations there may not be a suit played. For instance a single StoneCard.
+        _, count = most_common_tup[0]
+
     if count >= 5:
         return hand
     return []
+
 
 def is_consecutive(ordered_ranks: Sequence[int]) -> bool:
     prev_rank = ordered_ranks[0]
@@ -105,6 +111,7 @@ def is_consecutive(ordered_ranks: Sequence[int]) -> bool:
             return False
         prev_rank = rank
     return True
+
 
 def _get_straight(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
     sorted_ranks = sorted([card.rank.value.order for card in hand])

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -93,11 +93,11 @@ def _get_flush(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
         else:
             counter.update(card.suit)
 
-    most_common_tup = counter.most_common(1)
+    most_common_list = counter.most_common(1)
     count = 0
-    if len(most_common_tup) > 0:
+    if len(most_common_list) > 0:
         # In some situations there may not be a suit played. For instance a single StoneCard.
-        _, count = most_common_tup[0]
+        _, count = most_common_list[0]
 
     if count >= 5:
         return hand

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -1,13 +1,17 @@
 from typing import (
     Optional,
 )
+from unittest.mock import Mock, patch
 
 import pytest
 
+import balatro_gym.cards.interfaces
 from balatro_gym.cards.interfaces import (
     BonusCard,
     Edition,
     Enhancement,
+    GoldCard,
+    LuckyCard,
     MultCard,
     PlayingCard,
     Rank,
@@ -70,5 +74,42 @@ def test_enhancement_stone() -> None:
     enhancement = StoneCard()
     card = _make_card(enhancement=enhancement)
     assert card.enhancement == enhancement
-    assert card.get_chips() == 50
+    assert enhancement.get_chips() == 50
+    assert card.get_chips() == 50  # This is wrong, base chips shouldn't be in the sum
     assert len(card.suit) == 0
+
+
+@pytest.mark.unit
+def test_enhancement_gold() -> None:
+    enhancement = GoldCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert card.get_scored_money() == 0
+    assert card.get_end_money() == 3
+
+
+@pytest.mark.unit
+def test_enhancement_lucky() -> None:
+    enhancement = LuckyCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    with patch.object(balatro_gym.cards.interfaces, "np") as mock:
+        random_mock = Mock()
+        mock.random.random = random_mock
+        # Test degenerate cases
+        random_mock.return_value = 1
+        assert enhancement.get_mult() == 0
+        assert enhancement.get_scored_money() == 0
+        random_mock.return_value = 0
+        assert enhancement.get_mult() == 20
+        assert enhancement.get_scored_money() == 20
+        # Verify that the base probabilities are correct
+        random_mock.return_value = 1 / 5
+        assert enhancement.get_mult() == 20
+        random_mock.return_value = 1 / 15
+        assert enhancement.get_scored_money() == 20
+
+
+@pytest.mark.unit
+def test_enhancement_lucky_modifiers() -> None:
+    pass

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -1,0 +1,74 @@
+from typing import (
+    Optional,
+)
+
+import pytest
+
+from balatro_gym.cards.interfaces import (
+    BonusCard,
+    Edition,
+    Enhancement,
+    MultCard,
+    PlayingCard,
+    Rank,
+    Seal,
+    StoneCard,
+    Suit,
+    WildCard,
+)
+
+
+def _make_card(
+    rank: Rank = Rank.ACE,
+    suit: Suit = Suit.HEARTS,
+    enhancement: Optional[Enhancement] = None,
+    edition: Optional[Edition] = None,
+    seal: Optional[Seal] = None,
+) -> PlayingCard:
+    return PlayingCard(rank, suit, enhancement, edition, seal)
+
+
+@pytest.mark.unit
+def test_enhancement_bonus() -> None:
+    enhancement = BonusCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert card.get_chips() == 50 + card._base_chips
+
+
+@pytest.mark.unit
+def test_enhancement_mult() -> None:
+    enhancement = MultCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert card.get_mult() == 4
+
+
+@pytest.mark.unit
+def test_enhancement_wild() -> None:
+    enhancement = WildCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert len(set(card.suit)) == len(Suit)
+
+
+@pytest.mark.unit
+def test_enhancement_glass() -> None:
+    enhancement = MultCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert card.get_mult() == 4
+
+
+@pytest.mark.unit
+def test_enhancement_steel() -> None:
+    pass
+
+
+@pytest.mark.unit
+def test_enhancement_stone() -> None:
+    enhancement = StoneCard()
+    card = _make_card(enhancement=enhancement)
+    assert card.enhancement == enhancement
+    assert card.get_chips() == 50
+    assert len(card.suit) == 0


### PR DESCRIPTION
Add testing over card modifiers (enhancements, seals and editions)

Fixes a number of discovered bugs:
- Fixes probability of LuckyCard per [docs](https://balatrogame.fandom.com/wiki/Card_Modifiers)

Exposes information as needed:
- Suits and base suits in `PlayingCard`
- Money getters in `PlayingCard`

Closes #13