### PR TITLE
Add support for glass card destruction

### DIFF
--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -377,7 +377,10 @@ class Deck(HasReset):
     def destroy(self, cards: Sequence[PlayingCard]) -> None:
         """Destroyed cards are removed permanently. Though, this can only happen to cards in-play."""
         for card in cards:
-            self._cards_played.remove(card)
+            try:
+                self._cards_played.remove(card)
+            except ValueError:
+                print("Attempted to destroy card that wasn't played. This is unexpected.")
 
     def shuffle(self) -> None:
         cards = list(copy.deepcopy(self._cards_remaining))

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -12,6 +12,7 @@ from ..mixins import (
     HasChips,
     HasCreatePlanet,
     HasCreateTarot,
+    HasIsDestroyed,
     HasMoney,
     HasMult,
     HasMultiplier,
@@ -116,7 +117,7 @@ class Negative(Edition):
 
 
 # Enhancements
-class Enhancement(HasChips, HasMult, HasMultiplier, HasMoney, Protocol):
+class Enhancement(HasChips, HasMult, HasMultiplier, HasMoney, HasIsDestroyed, Protocol):
     def get_suit(self, card: "PlayingCard") -> Sequence[Suit]:
         return [card.base_suit]
 
@@ -137,9 +138,16 @@ class WildCard(Enhancement):
 
 
 class GlassCard(Enhancement):
+    _base_destruction_probability: float = 1 / 4
+
     def get_multiplication(self) -> float:
         # When scored
         return 2.0
+
+    def is_destroyed(self, probability_modifier: int = 1) -> bool:
+        if np.random.random() <= min(self._base_destruction_probability * probability_modifier, 1):
+            return True
+        return False
 
 
 class SteelCard(Enhancement):
@@ -369,7 +377,7 @@ class Deck(HasReset):
     def destroy(self, cards: Sequence[PlayingCard]) -> None:
         """Destroyed cards are removed permanently. Though, this can only happen to cards in-play."""
         for card in cards:
-            self._cards_remaining.remove(card)
+            self._cards_played.remove(card)
 
     def shuffle(self) -> None:
         cards = list(copy.deepcopy(self._cards_remaining))

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -62,10 +62,9 @@ def score_hand(hand: Sequence[PlayingCard], board_state: BoardState, blind_state
         mult_sum += card.get_mult() * num_card_retriggers
         mult_sum *= card.get_multiplication() * num_card_retriggers
         if isinstance(card.enhancement, LuckyCard):
-            money_sum += card.enhancement.get_scored_money()  # TODO See #25. %his should be influenced by jokers
-        if card.enhancement:
-            if card.enhancement.is_destroyed():  # TODO See #25. This should be influenced by jokers
-                board_state.deck.destroy([card])
+            money_sum += card.enhancement.get_scored_money()  # TODO See #25. this should be influenced by jokers
+        if card.enhancement and card.enhancement.is_destroyed():  # TODO See #25. This should be influenced by jokers
+            board_state.deck.destroy([card])
 
         for joker in board_state.jokers:
             # TODO track retriggers on jokers

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -62,8 +62,10 @@ def score_hand(hand: Sequence[PlayingCard], board_state: BoardState, blind_state
         mult_sum += card.get_mult() * num_card_retriggers
         mult_sum *= card.get_multiplication() * num_card_retriggers
         if isinstance(card.enhancement, LuckyCard):
-            money_sum += card.enhancement.get_scored_money()  # TODO this should be influenced by jokers
-        # TODO if card is glass, process the possible destruction
+            money_sum += card.enhancement.get_scored_money()  # TODO See #25. %his should be influenced by jokers
+        if card.enhancement:
+            if card.enhancement.is_destroyed():  # TODO See #25. This should be influenced by jokers
+                board_state.deck.destroy([card])
 
         for joker in board_state.jokers:
             # TODO track retriggers on jokers

--- a/src/balatro_gym/mixins.py
+++ b/src/balatro_gym/mixins.py
@@ -8,6 +8,12 @@ class HasChips(Protocol):
 
 
 @runtime_checkable
+class HasIsDestroyed(Protocol):
+    def is_destroyed(self, probability_modifier: int = 1) -> bool:
+        return False
+
+
+@runtime_checkable
 class HasMult(Protocol):
     def get_mult(self, probability_modifier: int = 1) -> int:
         # This is expected to be actively added. Thus we return 0 in the base case.

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -24,7 +24,7 @@ from balatro_gym.cards.interfaces import (
     WildCard,
 )
 from balatro_gym.game.scoring import get_poker_hand, score_hand
-from balatro_gym.interfaces import BoardState
+from balatro_gym.interfaces import BoardState, PokerHand, PokerHandType
 
 
 def _make_card(
@@ -93,6 +93,7 @@ def test_enhancement_glass_destroy(probability_modifier: int) -> None:
     submitted_hand = deck.deal(1)
     assert card in deck.cards_played
     board_mock = Mock()
+    board_mock.get_poker_hand.return_value = PokerHand(PokerHandType.HIGH_CARD, 1, 0)
     board_mock.jokers = []  # TODO See #25. This can influence probabilities and should be tested.
     board_mock.deck = deck
     blind_mock = Mock()

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -8,6 +8,7 @@ import pytest
 import balatro_gym.cards.interfaces
 from balatro_gym.cards.interfaces import (
     BonusCard,
+    Deck,
     Edition,
     Enhancement,
     GlassCard,
@@ -80,7 +81,27 @@ def test_enhancement_glass_scoring() -> None:
     _, hand_type = get_poker_hand(submitted_hand)
     expected_score = (hand_type.value.chips + card.get_chips()) * hand_type.value.mult * card.get_multiplication()
     assert score == expected_score
-    # TODO MAX test card destruction
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("probability_modifier", [1, 2, 10])
+def test_enhancement_glass_destroy(probability_modifier: int) -> None:
+    enhancement = GlassCard()
+    card = _make_card(enhancement=enhancement)
+    deck = Deck([card])
+    submitted_hand = deck.deal(1)
+    assert card in deck.cards_played
+    board_mock = Mock()
+    board_mock.jokers = []  # TODO See #25. This can influence probabilities and should be tested.
+    board_mock.deck = deck
+    blind_mock = Mock()
+    blind_mock.hand = []
+    with patch.object(balatro_gym.cards.interfaces, "np") as mock:
+        random_mock = Mock()
+        mock.random.random = random_mock
+        random_mock.return_value = 0
+        score_hand(submitted_hand, board_mock, blind_mock)
+        assert card not in board_mock.deck.cards_played
 
 
 @pytest.mark.unit

--- a/test/cards/test_deck.py
+++ b/test/cards/test_deck.py
@@ -49,7 +49,7 @@ def test_destroy() -> None:
     deck = Deck(initial_cards)
     deck.destroy([])
     assert len(initial_cards) == len(deck.cards_remaining)
-    destroy_cards = [ACE_HEART]
+    destroy_cards = deck.deal(1)
     deck.destroy(destroy_cards)
     assert len(initial_cards) == len(deck.cards_remaining) + len(destroy_cards)
 


### PR DESCRIPTION
This adds support for processing `GlassCard` destruction in the scoring function and adds testing.

Opens #25 to track probability processing in general.