### PR TITLE
Add whitespace rules to ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ markers = [
 ]
 
 [tool.ruff]
+lint.preview = true
+format.preview = true
 lint.extend-select = ["I", "E", "W", "Q", "F401"]
 line-length = 120
 

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -13,6 +13,7 @@ def _cards_idxs(cards: Sequence[str]) -> Sequence[int]:
             pass
     return card_idxs
 
+
 if __name__ == "__main__":
     run = Run()
     done = False
@@ -41,7 +42,6 @@ if __name__ == "__main__":
             else:
                 action = HandAction.SCORE_HAND
             run.step(GameAction(action, cards))
-
 
         elif obs.game_state == GameState.IN_BLIND_SELECT:
             print("You are in blind selection.")

--- a/src/balatro_gym/cards/decks.py
+++ b/src/balatro_gym/cards/decks.py
@@ -5,7 +5,7 @@ from .interfaces import PlayingCard, Rank, Suit
 
 STANDARD_DECK: Sequence[PlayingCard] = [
     PlayingCard(rank, suit, None, None, None)
-    for suit, rank in itertools.product([suit for suit in Suit], [rank for rank in Rank]) # type: ignore
+    for suit, rank in itertools.product([suit for suit in Suit], [rank for rank in Rank])  # type: ignore
 ]
 
 

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -25,6 +25,7 @@ class Suit(Enum):
     DIAMONDS = auto()
     HEARTS = auto()
 
+
 class RankVal:
     """An annoying workaround to allow using an Enum since aenum doesn't have good typing support."""
     _val: int
@@ -41,6 +42,7 @@ class RankVal:
     @property
     def order(self) -> int:
         return self._order
+
 
 class Rank(Enum):
     ACE = RankVal(11, 1)
@@ -81,7 +83,7 @@ class Rank(Enum):
         return self
 
 
-############# Editions
+# Editions
 class Edition(HasChips, HasMult, HasMultiplier, Protocol):
     def is_negative(self) -> bool:
         return False
@@ -111,7 +113,7 @@ class Negative(Edition):
         return True
 
 
-############# Enhancements
+# Enhancements
 class Enhancement(HasChips, HasMult, HasMultiplier, HasMoney, Protocol):
     def get_suit(self, card: "PlayingCard") -> Sequence[Suit]:
         return [card.suit]
@@ -300,6 +302,7 @@ class PlayingCard(HasChips):
             + hash(self._base_chips) \
             + hash(self._seal) \
             + hash(self._added_chips)
+
 
 class Deck(HasReset):
     _cards_remaining: deque[PlayingCard]

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -82,7 +82,7 @@ def score_hand(hand: Sequence[PlayingCard], board_state: BoardState, blind_state
     return chips_sum * mult_sum
 
 
-###### These are broken out for testability
+# These are broken out for testability
 
 
 def _get_flush(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
@@ -98,6 +98,7 @@ def _get_flush(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
         return hand
     return []
 
+
 def is_consecutive(ordered_ranks: Sequence[int]) -> bool:
     prev_rank = ordered_ranks[0]
     for rank in ordered_ranks[1:]:
@@ -105,6 +106,7 @@ def is_consecutive(ordered_ranks: Sequence[int]) -> bool:
             return False
         prev_rank = rank
     return True
+
 
 def _get_straight(hand: Sequence[PlayingCard]) -> Sequence[PlayingCard]:
     sorted_ranks = sorted([card.rank.value.order for card in hand])

--- a/test/cards/test_deck.py
+++ b/test/cards/test_deck.py
@@ -14,12 +14,14 @@ def test_deck_shuffle() -> None:
     deck.shuffle()
     assert deck.cards_remaining != initial_cards
 
+
 def _count_cards(deck: Deck, card: PlayingCard) -> int:
     total = 0
     for c in deck.cards_remaining:
         if c == card:
-            total+=1
+            total += 1
     return total
+
 
 @pytest.mark.unit
 def test_add() -> None:
@@ -28,8 +30,9 @@ def test_add() -> None:
     assert len(deck.cards_remaining) == len(initial_cards)
     assert _count_cards(deck, ACE_HEART) == 1
     deck.add([ACE_HEART])
-    assert len(deck.cards_remaining) == len(initial_cards) +1
+    assert len(deck.cards_remaining) == len(initial_cards) + 1
     assert _count_cards(deck, ACE_HEART) == 2
+
 
 @pytest.mark.unit
 def test_deal() -> None:
@@ -38,6 +41,7 @@ def test_deal() -> None:
     delt = deck.deal(5)
     assert len(initial_cards) == len(deck.cards_played) + len(deck.cards_remaining)
     assert delt == deck.cards_played
+
 
 @pytest.mark.unit
 def test_destroy() -> None:
@@ -59,6 +63,7 @@ def test_eq_ordering() -> None:
     deck2.shuffle()
     assert deck1 != deck2
 
+
 @pytest.mark.unit
 def test_eq_card_action() -> None:
     initial_cards = STANDARD_DECK
@@ -69,6 +74,7 @@ def test_eq_card_action() -> None:
     assert deck1 != deck2
     deck2._cards_remaining.append(ACE_HEART)
     assert deck1 == deck2
+
 
 @pytest.mark.unit
 def test_reset() -> None:

--- a/test/game/test_engine.py
+++ b/test/game/test_engine.py
@@ -17,12 +17,14 @@ def test_game_reset() -> None:
     assert len(run.blinds) > 0
     assert run.action_counter == 0
 
+
 @pytest.mark.unit
 def test_process_board_action_state_transition() -> None:
     run = Run()
     assert run.game_state == GameState.IN_BLIND_SELECT
     run._process_board_action(GameAction(BoardAction.START_ANTE, []))
     assert run.game_state == GameState.IN_ANTE
+
 
 @pytest.mark.unit
 def test_process_hand_action_state_transition_win() -> None:
@@ -31,8 +33,9 @@ def test_process_hand_action_state_transition_win() -> None:
     run._process_board_action(GameAction(BoardAction.START_ANTE, []))
     assert run.blind_state
     req_score = run.blind_state.required_score
-    with patch("balatro_gym.game.engine.score_hand", lambda x,y,z: req_score+1):
+    with patch("balatro_gym.game.engine.score_hand", lambda x, y, z: req_score + 1):
         assert run._process_hand_action(GameAction(HandAction.SCORE_HAND, [run.blind_state.hand[0]])) is True
+
 
 @pytest.mark.unit
 def test_process_hand_action_state_transition_loss() -> None:
@@ -42,10 +45,11 @@ def test_process_hand_action_state_transition_loss() -> None:
     assert run.blind_state
     num_hands = run.blind_state.num_hands_remaining
     terminal = False
-    with patch("balatro_gym.game.engine.score_hand", lambda x,y,z: 0):
+    with patch("balatro_gym.game.engine.score_hand", lambda x, y, z: 0):
         for i in range(num_hands):
             terminal &= run._process_hand_action(GameAction(HandAction.SCORE_HAND, [run.blind_state.hand[0]]))
     assert terminal is False
+
 
 @pytest.mark.unit
 def test_process_hand_action_discard() -> None:
@@ -53,7 +57,7 @@ def test_process_hand_action_discard() -> None:
     run._process_board_action(GameAction(BoardAction.START_ANTE, []))
     assert run.blind_state
     num_discards = run.blind_state.num_discards_reamining
-    for i in range(1, num_discards+1):
+    for i in range(1, num_discards + 1):
         run._process_hand_action(GameAction(HandAction.DISCARD, [run.blind_state.hand[0]]))
         assert num_discards == run.blind_state.num_discards_reamining + i
 
@@ -61,6 +65,7 @@ def test_process_hand_action_discard() -> None:
     old_blind_state = copy.deepcopy(run.blind_state)
     run._process_hand_action(GameAction(HandAction.DISCARD, [run.blind_state.hand[0]]))
     assert old_blind_state == run.blind_state
+
 
 @pytest.mark.unit
 def test_setup_ante() -> None:


### PR DESCRIPTION
Namely adds [E305](https://docs.astral.sh/ruff/rules/blank-lines-after-function-or-class/#blank-lines-after-function-or-class-e305) and [E252](https://docs.astral.sh/ruff/rules/missing-whitespace-around-parameter-equals/) which controls newline spacing between functions, and whitespace between parameters respectively.