### PR TITLE
generate buyable cards

### DIFF
--- a/src/balatro_gym/cards/booster_packs.py
+++ b/src/balatro_gym/cards/booster_packs.py
@@ -60,7 +60,7 @@ class ArcanaPack(Booster):
     n_choice: int
 
     def sample(self) -> Sequence[HasCost]:
-        return random.sample(TAROT_CARDS, self.n_cards)
+        return [card() for card in random.sample(TAROT_CARDS, self.n_cards)]
 
 
 @dataclasses.dataclass
@@ -70,7 +70,7 @@ class CelestialPack(Booster):
     n_choice: int
 
     def sample(self) -> Sequence[HasCost]:
-        return random.sample(PLANET_CARDS, self.n_cards)
+        return [card() for card in random.sample(PLANET_CARDS, self.n_cards)]
 
 
 @dataclasses.dataclass
@@ -81,7 +81,7 @@ class BuffoonPack(Booster):
 
     def sample(self) -> Sequence[HasCost]:
         # TODO: add enhancements and consider joker rarity
-        return random.sample(JOKERS, self.n_cards)
+        return [card() for card in random.sample(JOKERS, self.n_cards)]
 
 
 @dataclasses.dataclass
@@ -91,7 +91,7 @@ class SpectralPack(Booster):
     n_choice: int
 
     def sample(self) -> Sequence[HasCost]:
-        return random.sample(SPECTRAL_CARDS, self.n_cards)
+        return [card() for card in random.sample(SPECTRAL_CARDS, self.n_cards)]
 
 
 class BoosterType(enum.Enum):

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -1,10 +1,9 @@
 import copy
-import dataclasses
 import random
 from collections import deque
 from collections.abc import Sequence
 from enum import Enum, auto
-from typing import Any, Optional, Protocol, Union
+from typing import Any, Optional, Protocol, Union, runtime_checkable
 
 import numpy as np
 
@@ -209,7 +208,7 @@ class PurpleSeal(Seal):
         return True
 
 
-@dataclasses.dataclass
+@runtime_checkable
 class HasCost(Protocol):
     _cost: int = 1
 

--- a/src/balatro_gym/cards/joker.py
+++ b/src/balatro_gym/cards/joker.py
@@ -3,8 +3,6 @@ from collections.abc import Sequence
 from ..interfaces import BlindState, JokerBase, PokerHandType, Rarity, Type
 from .interfaces import PlayingCard, Suit
 
-JOKERS: Sequence[JokerBase] = []
-
 
 class Joker(JokerBase):
 
@@ -120,3 +118,8 @@ class ZanyJoker(JokerBase):
         if scored_hand == PokerHandType.THREE_SET:
             return 12
         return 0
+
+
+JOKERS: Sequence[JokerBase] = [
+    Joker(), GreedyJoker(), LustyJoker(), WrathfulJoker(), GluttonousJoker(), JollyJoker(), ZanyJoker()
+]

--- a/src/balatro_gym/cards/joker.py
+++ b/src/balatro_gym/cards/joker.py
@@ -120,6 +120,6 @@ class ZanyJoker(JokerBase):
         return 0
 
 
-JOKERS: Sequence[JokerBase] = [
+JOKERS: set[JokerBase] = {
     Joker(), GreedyJoker(), LustyJoker(), WrathfulJoker(), GluttonousJoker(), JollyJoker(), ZanyJoker()
-]
+}

--- a/src/balatro_gym/cards/joker.py
+++ b/src/balatro_gym/cards/joker.py
@@ -120,6 +120,6 @@ class ZanyJoker(JokerBase):
         return 0
 
 
-JOKERS: set[JokerBase] = {
-    Joker(), GreedyJoker(), LustyJoker(), WrathfulJoker(), GluttonousJoker(), JollyJoker(), ZanyJoker()
-}
+JOKERS: list[type[JokerBase]] = [
+    Joker, GreedyJoker, LustyJoker, WrathfulJoker, GluttonousJoker, JollyJoker, ZanyJoker
+]

--- a/src/balatro_gym/cards/planet.py
+++ b/src/balatro_gym/cards/planet.py
@@ -8,4 +8,4 @@ class Pluto(PlanetCard):
         return PokerHandType.HIGH_CARD
 
 
-PLANET_CARDS: set[PlanetCard] = {Pluto()}
+PLANET_CARDS: list[type[PlanetCard]] = [Pluto]

--- a/src/balatro_gym/cards/planet.py
+++ b/src/balatro_gym/cards/planet.py
@@ -1,5 +1,12 @@
 from typing import Sequence
 
-from balatro_gym.interfaces import PlanetCard
+from balatro_gym.interfaces import PlanetCard, PokerHandType
 
-PLANET_CARDS: Sequence[PlanetCard] = []
+
+class Pluto(PlanetCard):
+    @property
+    def _hand_type(self) -> PokerHandType:
+        return PokerHandType.HIGH_CARD
+
+
+PLANET_CARDS: Sequence[PlanetCard] = [Pluto()]

--- a/src/balatro_gym/cards/planet.py
+++ b/src/balatro_gym/cards/planet.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 
 from balatro_gym.interfaces import PlanetCard, PokerHandType
 
@@ -9,4 +8,4 @@ class Pluto(PlanetCard):
         return PokerHandType.HIGH_CARD
 
 
-PLANET_CARDS: Sequence[PlanetCard] = [Pluto()]
+PLANET_CARDS: set[PlanetCard] = {Pluto()}

--- a/src/balatro_gym/cards/spectral.py
+++ b/src/balatro_gym/cards/spectral.py
@@ -1,4 +1,4 @@
 
 from balatro_gym.interfaces import Spectral
 
-SPECTRAL_CARDS: set[Spectral] = set()
+SPECTRAL_CARDS: list[type[Spectral]] = []

--- a/src/balatro_gym/cards/spectral.py
+++ b/src/balatro_gym/cards/spectral.py
@@ -1,5 +1,4 @@
-from typing import Sequence
 
 from balatro_gym.interfaces import Spectral
 
-SPECTRAL_CARDS: Sequence[Spectral] = []
+SPECTRAL_CARDS: set[Spectral] = set()

--- a/src/balatro_gym/cards/tarot.py
+++ b/src/balatro_gym/cards/tarot.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 
 from balatro_gym.interfaces import Tarot
 
@@ -7,4 +6,4 @@ class Fool(Tarot):
     pass
 
 
-TAROT_CARDS: Sequence[Tarot] = [Fool()]
+TAROT_CARDS: set[Tarot] = {Fool()}

--- a/src/balatro_gym/cards/tarot.py
+++ b/src/balatro_gym/cards/tarot.py
@@ -2,4 +2,9 @@ from typing import Sequence
 
 from balatro_gym.interfaces import Tarot
 
-TAROT_CARDS: Sequence[Tarot] = []
+
+class Fool(Tarot):
+    pass
+
+
+TAROT_CARDS: Sequence[Tarot] = [Fool()]

--- a/src/balatro_gym/cards/tarot.py
+++ b/src/balatro_gym/cards/tarot.py
@@ -6,4 +6,4 @@ class Fool(Tarot):
     pass
 
 
-TAROT_CARDS: set[Tarot] = {Fool()}
+TAROT_CARDS: list[type[Tarot]] = [Fool]

--- a/src/balatro_gym/game/scoring.py
+++ b/src/balatro_gym/game/scoring.py
@@ -51,9 +51,9 @@ def score_hand(hand: Sequence[PlayingCard], board_state: BoardState, blind_state
                     4) subtract multiplication | round
     """
     cards, hand_type = get_poker_hand(hand)
-    hand_val = hand_type.value
-    chips_sum = hand_val.chips
-    mult_sum: float = hand_val.mult
+    poker_scale = board_state.get_poker_hand(hand_type).score
+    chips_sum = poker_scale.chips
+    mult_sum: float = poker_scale.mult
     money_sum = 0
 
     for card in cards:

--- a/src/balatro_gym/game/shop.py
+++ b/src/balatro_gym/game/shop.py
@@ -16,8 +16,8 @@ from balatro_gym.cards.tarot import TAROT_CARDS
 from balatro_gym.cards.voucher import ALL_VOUCHERS
 from balatro_gym.interfaces import Booster, Voucher
 
-
 __all__ = ["Shop"]
+
 
 @dataclasses.dataclass
 class ShopState:

--- a/src/balatro_gym/game/shop.py
+++ b/src/balatro_gym/game/shop.py
@@ -17,6 +17,8 @@ from balatro_gym.cards.voucher import ALL_VOUCHERS
 from balatro_gym.interfaces import Booster, Voucher
 
 
+__all__ = ["Shop"]
+
 @dataclasses.dataclass
 class ShopState:
     buyable_cards: Sequence[HasCost]

--- a/src/balatro_gym/game/shop.py
+++ b/src/balatro_gym/game/shop.py
@@ -4,6 +4,9 @@ from typing import Sequence
 
 from balatro_gym.cards.booster_packs import BOOSTER_TO_PACK_INFO, BoosterType, PackType
 from balatro_gym.cards.interfaces import HasCost
+from balatro_gym.cards.joker import JOKERS
+from balatro_gym.cards.planet import PLANET_CARDS
+from balatro_gym.cards.tarot import TAROT_CARDS
 from balatro_gym.cards.voucher import ALL_VOUCHERS
 from balatro_gym.interfaces import Booster, Voucher
 
@@ -73,7 +76,7 @@ class Shop:
             self.vouchers = self.voucher_generator()
         return ShopState(
             vouchers=self.vouchers,
-            buyable_cards=[],
+            buyable_cards=self.generate_buyable_cards(),
             booster_packs=self.generate_booster_packs(),
         )
 
@@ -88,3 +91,17 @@ class Shop:
                 probabilities.append(PROBABILITY_MAPPING[booster_type][pack_type])
 
         return random.choices(potential_packs, weights=probabilities, k=self.num_booster_packs)
+
+    def generate_buyable_cards(self) -> Sequence[HasCost]:
+        sampled_cards: list[HasCost] = []
+        for _ in range(self.num_buyable_slots):
+            rand = random.random()
+            # The probabilities are based on numbers provided by https://balatrogame.fandom.com/wiki/The_Shop
+            if rand < 1 / 7:
+                sampled_cards.extend(random.sample(TAROT_CARDS, 1))
+            elif rand < 2 / 7:
+                sampled_cards.extend(random.sample(PLANET_CARDS, 1))
+            else:
+                # TODO: Consider rarity when sampling jokers
+                sampled_cards.extend(random.sample(JOKERS, 1))
+        return sampled_cards

--- a/src/balatro_gym/game/shop.py
+++ b/src/balatro_gym/game/shop.py
@@ -8,7 +8,7 @@ from balatro_gym.cards.joker import JOKERS
 from balatro_gym.cards.planet import PLANET_CARDS
 from balatro_gym.cards.tarot import TAROT_CARDS
 from balatro_gym.cards.voucher import ALL_VOUCHERS
-from balatro_gym.interfaces import Booster, Tarot, Voucher
+from balatro_gym.interfaces import Booster, Voucher
 
 
 @dataclasses.dataclass
@@ -100,7 +100,7 @@ class Shop:
         all_tarot_cards = TAROT_CARDS
         all_planet_cards = PLANET_CARDS
         all_joker_cards = JOKERS
-        card : HasCost
+        card: HasCost
         for _ in range(self.num_buyable_slots):
             rand = random.random()
             # The probabilities are based on numbers provided by https://balatrogame.fandom.com/wiki/The_Shop

--- a/src/balatro_gym/game/shop.py
+++ b/src/balatro_gym/game/shop.py
@@ -110,10 +110,11 @@ class Shop:
 
     def generate_buyable_cards(self) -> Sequence[HasCost]:
         sampled_cards: list[HasCost] = []
-        all_tarot_cards = TAROT_CARDS
-        all_planet_cards = PLANET_CARDS
-        all_joker_cards = JOKERS
-        card: HasCost
+        # Provide a copy of the lists
+        all_tarot_cards = [card for card in TAROT_CARDS]
+        all_planet_cards = [card for card in PLANET_CARDS]
+        all_joker_cards = [card for card in JOKERS]
+        card: type[HasCost]
         for _ in range(self.num_buyable_slots):
             rand = random.random()
             # The probabilities are based on numbers provided by https://balatrogame.fandom.com/wiki/The_Shop
@@ -122,13 +123,13 @@ class Shop:
                 if not self.allow_duplicates:
                     all_tarot_cards.remove(card)
             elif rand < 2 / 7:
-                card = random.sample(PLANET_CARDS, 1)[0]
+                card = random.sample(all_planet_cards, 1)[0]
                 if not self.allow_duplicates:
                     all_planet_cards.remove(card)
             else:
                 # TODO: Consider rarity when sampling jokers
-                card = random.sample(JOKERS, 1)[0]
+                card = random.sample(all_joker_cards, 1)[0]
                 if not self.allow_duplicates:
                     all_joker_cards.remove(card)
-            sampled_cards.append(card)
+            sampled_cards.append(card())
         return sampled_cards

--- a/src/balatro_gym/interfaces.py
+++ b/src/balatro_gym/interfaces.py
@@ -86,22 +86,24 @@ class Type(Enum):
 class PokerScale:
     mult: int
     chips: int
+    delta_mult: int
+    delta_chips: int
 
 
 class PokerHandType(Enum):
-    HIGH_CARD = PokerScale(1, 5)
-    PAIR = PokerScale(2, 10)
-    TWO_PAIR = PokerScale(2, 20)
-    THREE_SET = PokerScale(3, 30)
-    FULL_HOUSE = PokerScale(4, 40)
-    FLUSH_HOUSE = PokerScale(14, 140)
-    FOUR_SET = PokerScale(7, 60)
-    FIVE_SET = PokerScale(12, 120)
-    FLUSH = PokerScale(4, 35)
-    ROYAL_FLUSH = PokerScale(8, 100)
-    STRAIGHT = PokerScale(4, 30)
-    STRAIGHT_FLUSH = PokerScale(8, 100)
-    FLUSH_FIVE = PokerScale(16, 160)
+    HIGH_CARD = PokerScale(1, 5, 1, 10)
+    PAIR = PokerScale(2, 10, 1, 15)
+    TWO_PAIR = PokerScale(2, 20, 1, 20)
+    THREE_SET = PokerScale(3, 30, 2, 20)
+    FULL_HOUSE = PokerScale(4, 40, 2, 25)
+    FLUSH_HOUSE = PokerScale(14, 140, 4, 40)
+    FOUR_SET = PokerScale(7, 60, 3, 30)
+    FIVE_SET = PokerScale(12, 120, 3, 35)
+    FLUSH = PokerScale(4, 35, 2, 15)
+    ROYAL_FLUSH = PokerScale(8, 100, 4, 40)
+    STRAIGHT = PokerScale(4, 30, 3, 30)
+    STRAIGHT_FLUSH = PokerScale(8, 100, 4, 40)
+    FLUSH_FIVE = PokerScale(16, 160, 3, 50)
 
 
 class ConsumableCardBase: ...
@@ -114,15 +116,19 @@ class PokerHand:
     num_played: int
 
     @property
-    def base_score(self) -> PokerScale:
+    def score(self) -> PokerScale:
         return PokerScale(
-            self.hand_type.value.mult * self.level,
-            self.hand_type.value.chips * self.level,
+            self.hand_type.value.mult + self.hand_type.value.delta_mult * (self.level - 1),
+            self.hand_type.value.chips + self.hand_type.value.delta_chips * (self.level - 1),
+            self.hand_type.value.delta_mult,
+            self.hand_type.value.delta_chips,
         )
 
 
 class PlanetCard(HasCost):
-    _hand_type: PokerHandType
+    @property
+    def _hand_type(self) -> PokerHandType:
+        raise NotImplementedError
 
     def increase_level(self, poker_hands: Sequence[PokerHand]) -> PokerHand:
         for hand in poker_hands:
@@ -221,7 +227,7 @@ class BoardState(HasReset):
     num_discards: int
     hand_size: int
     vouchers: Sequence[Voucher]
-    poker_hands: Sequence[PokerHand]
+    poker_hands: dict[str, PokerHand]
     completed_blinds: Sequence[BlindInfo]
     """Shows all blinds that have been completed, ordered."""
     round_blinds: Sequence[BlindInfo]
@@ -241,6 +247,9 @@ class BoardState(HasReset):
         self.num_discards = 3
         self.hand_size = 8
         self.vouchers = []
-        self.poker_hands = []
+        self.poker_hands = {poker_hand_type.name: PokerHand(poker_hand_type, 1, 0) for poker_hand_type in PokerHandType}
         self.completed_blinds = []
         self.round_blinds = []
+
+    def get_poker_hand(self, poker_hand_type: PokerHandType) -> PokerHand:
+        return self.poker_hands[poker_hand_type.name]

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -23,6 +23,7 @@ from balatro_gym.cards.interfaces import (
     WildCard,
 )
 from balatro_gym.game.scoring import get_poker_hand, score_hand
+from balatro_gym.interfaces import BoardState
 
 
 def _make_card(
@@ -71,7 +72,7 @@ def test_enhancement_glass() -> None:
 def test_enhancement_glass_scoring() -> None:
     enhancement = GlassCard()
     card = _make_card(enhancement=enhancement)
-    board_mock = Mock()
+    board_mock = BoardState()
     board_mock.jokers = []
     blind_mock = Mock()
     blind_mock.hand = []
@@ -98,7 +99,7 @@ def test_enhancement_steel_scoring() -> None:
     held_card = _make_card(enhancement=enhancement)
     submitted_card = _make_card()
     submitted_hand = [submitted_card]
-    board_mock = Mock()
+    board_mock = BoardState()
     board_mock.jokers = []
     blind_mock = Mock()
     blind_mock.hand = [held_card]
@@ -128,7 +129,7 @@ def test_enhancement_stone_scoring() -> None:
     # Submit a single stone card
     enhancement = StoneCard()
     card = _make_card(enhancement=enhancement)
-    board_mock = Mock()
+    board_mock = BoardState()
     board_mock.jokers = []
     blind_mock = Mock()
     blind_mock.hand = []

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -72,12 +72,12 @@ def test_enhancement_glass() -> None:
 def test_enhancement_glass_scoring() -> None:
     enhancement = GlassCard()
     card = _make_card(enhancement=enhancement)
-    board_mock = BoardState()
-    board_mock.jokers = []
+    board = BoardState()
+    board.jokers = []
     blind_mock = Mock()
     blind_mock.hand = []
     submitted_hand = [card]
-    score = score_hand(submitted_hand, board_mock, blind_mock)
+    score = score_hand(submitted_hand, board, blind_mock)
     _, hand_type = get_poker_hand(submitted_hand)
     expected_score = (hand_type.value.chips + card.get_chips()) * hand_type.value.mult * card.get_multiplication()
     assert score == expected_score
@@ -99,11 +99,11 @@ def test_enhancement_steel_scoring() -> None:
     held_card = _make_card(enhancement=enhancement)
     submitted_card = _make_card()
     submitted_hand = [submitted_card]
-    board_mock = BoardState()
-    board_mock.jokers = []
+    board = BoardState()
+    board.jokers = []
     blind_mock = Mock()
     blind_mock.hand = [held_card]
-    score = score_hand(submitted_hand, board_mock, blind_mock)
+    score = score_hand(submitted_hand, board, blind_mock)
     _, hand_type = get_poker_hand(submitted_hand)
     expected_score = (
         (hand_type.value.chips + submitted_card.get_chips())
@@ -129,12 +129,12 @@ def test_enhancement_stone_scoring() -> None:
     # Submit a single stone card
     enhancement = StoneCard()
     card = _make_card(enhancement=enhancement)
-    board_mock = BoardState()
-    board_mock.jokers = []
+    board = BoardState()
+    board.jokers = []
     blind_mock = Mock()
     blind_mock.hand = []
     submitted_hand = [card]
-    score = score_hand(submitted_hand, board_mock, blind_mock)
+    score = score_hand(submitted_hand, board, blind_mock)
     _, hand_type = get_poker_hand(submitted_hand)
     expected_score = (hand_type.value.chips + card.get_chips()) * hand_type.value.mult * card.get_multiplication()
     assert score == expected_score

--- a/test/game/test_shop.py
+++ b/test/game/test_shop.py
@@ -1,7 +1,7 @@
 import pytest
 
-from balatro_gym.cards.interfaces import HasCost
 from balatro_gym.cards.booster_packs import BuffoonPack
+from balatro_gym.cards.interfaces import HasCost
 from balatro_gym.cards.voucher import ALL_VOUCHERS
 from balatro_gym.game.shop import Shop, ShopState
 from balatro_gym.interfaces import Booster
@@ -9,7 +9,7 @@ from balatro_gym.interfaces import Booster
 
 @pytest.mark.unit
 def test_generate_shop_state() -> None:
-    shop = Shop()
+    shop = Shop(allow_duplicates=True)
     state = shop.generate_shop_state(1)
     voucher = state.vouchers[0]
     assert isinstance(state, ShopState)

--- a/test/game/test_shop.py
+++ b/test/game/test_shop.py
@@ -1,5 +1,6 @@
 import pytest
 
+from balatro_gym.cards.interfaces import HasCost
 from balatro_gym.cards.voucher import ALL_VOUCHERS
 from balatro_gym.game.shop import Shop, ShopState
 from balatro_gym.interfaces import Booster
@@ -21,6 +22,8 @@ def test_generate_shop_state() -> None:
     assert len(state.vouchers) == 0
     # We should have a new voucher
     assert any([shop.generate_shop_state(4).vouchers[0] != voucher for _ in range(5)])
+    assert len(state.buyable_cards) == 2
+    assert all([isinstance(card, HasCost) for card in state.buyable_cards])
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The goal of this PR is to add `generate_buyable_cards` to the shop. To do so, I had to have at least one type of each card to sample 1 card which led me to implement `Pluto`. Following that addition I fixed the `PokerHand.base_score` as the score should be `base_chips + delta_chips * (level -1) ....` not just `base_chips * level`.

I'll add the rest of the planet cards and tarot cards in a follow up PR