### PR TITLE
Improve HasCost protocol

### DIFF
--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -21,6 +21,8 @@ from ..mixins import (
 from .voucher import ClearanceSale, Liquidation, Voucher
 
 
+__all__ = ["HasCost"]
+
 class Suit(Enum):
     SPADES = auto()
     CLUBS = auto()

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -18,6 +18,7 @@ from ..mixins import (
     HasReset,
     HasRetrigger,
 )
+from .voucher import ClearanceSale, Liquidation, Voucher
 
 
 class Suit(Enum):
@@ -219,6 +220,22 @@ class PurpleSeal(Seal):
 @runtime_checkable
 class HasCost(Protocol):
     _cost: int = 1
+
+    def cost(self, vouchers: Sequence[Voucher]) -> int:
+        cost: float = self._cost
+        if any([isinstance(voucher, Liquidation) for voucher in vouchers]):
+            cost -= cost * 0.5
+        elif any([isinstance(voucher, ClearanceSale) for voucher in vouchers]):
+            cost -= cost * 0.25
+        return max(int(cost), 1)
+
+    def sell_value(self, vouchers: Sequence[Voucher]) -> int:
+        sell_value: float = self._cost
+        if any([isinstance(voucher, Liquidation) for voucher in vouchers]):
+            sell_value -= sell_value * 0.5
+        elif any([isinstance(voucher, ClearanceSale) for voucher in vouchers]):
+            sell_value -= sell_value * 0.25
+        return max(int(sell_value * 0.5), 1)
 
 
 class PlayingCard(HasChips, HasCost):

--- a/src/balatro_gym/cards/interfaces.py
+++ b/src/balatro_gym/cards/interfaces.py
@@ -20,8 +20,8 @@ from ..mixins import (
 )
 from .voucher import ClearanceSale, Liquidation, Voucher
 
-
 __all__ = ["HasCost"]
+
 
 class Suit(Enum):
     SPADES = auto()

--- a/src/balatro_gym/cards/voucher.py
+++ b/src/balatro_gym/cards/voucher.py
@@ -1,7 +1,16 @@
 import dataclasses
-from typing import Optional
+from typing import Any, Optional
 
-from balatro_gym.interfaces import Voucher
+
+@dataclasses.dataclass(frozen=True)
+class Voucher:
+    dependency: Optional["Voucher"]
+
+    def __hash__(self) -> int:
+        return hash(self.__class__.__name__)
+
+    def __eq__(self, obj: Any) -> bool:
+        return obj._class__.__name__ == self.__class__.__name__
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/balatro_gym/interfaces.py
+++ b/src/balatro_gym/interfaces.py
@@ -1,10 +1,11 @@
 import dataclasses
 from collections.abc import Sequence
 from enum import Enum, auto
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from .cards.decks import STANDARD_DECK
 from .cards.interfaces import Deck, HasCost, PlayingCard
+from .cards.voucher import Voucher
 from .constants import DEFAULT_NUM_CONSUMABLE, DEFAULT_START_MONEY
 from .game.blinds import BlindInfo
 from .mixins import HasReset
@@ -26,17 +27,6 @@ __all__ = [
 
 class Tag:
     pass
-
-
-@dataclasses.dataclass(frozen=True)
-class Voucher:
-    dependency: Optional["Voucher"]
-
-    def __hash__(self) -> int:
-        return hash(self.__class__.__name__)
-
-    def __eq__(self, obj: Any) -> bool:
-        return obj._class__.__name__ == self.__class__.__name__
 
 
 class Spectral(HasCost):
@@ -185,9 +175,8 @@ class JokerBase(HasCost):
     def base_cost(self) -> int:
         return self._cost
 
-    def cost(self, vouchers: Sequence[Voucher]) -> int:
-        # TODO. Voucher impl doesn't exist yet, which may impact this.
-        return self._cost
+    # TODO: implement cost method that considers the edition to override the base implementation
+    # def cost(self, vouchers: Sequence[Vouchers]) -> int:
 
     @property
     def rarity(self) -> Rarity:

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -1,5 +1,6 @@
 from typing import (
-    Optional, Sequence,
+    Optional,
+    Sequence,
 )
 from unittest.mock import Mock, patch
 

--- a/test/cards/test_cards.py
+++ b/test/cards/test_cards.py
@@ -1,5 +1,5 @@
 from typing import (
-    Optional,
+    Optional, Sequence,
 )
 from unittest.mock import Mock, patch
 
@@ -23,7 +23,9 @@ from balatro_gym.cards.interfaces import (
     Suit,
     WildCard,
 )
+from balatro_gym.cards.joker import GreedyJoker
 from balatro_gym.cards.planet import Mercury, Pluto
+from balatro_gym.cards.voucher import ClearanceSale, Liquidation, Voucher
 from balatro_gym.game.scoring import get_poker_hand, score_hand
 from balatro_gym.interfaces import BoardState, PokerHand, PokerHandType
 
@@ -229,3 +231,23 @@ def test_planet_cards() -> None:
     pluto.decrease_level(poker_hands)
     assert poker_hands[0].level == initial_level_high_card
     assert poker_hands[1].level == initial_level_pair
+
+
+@pytest.mark.unit
+def test_sell_and_cost_value() -> None:
+    cost = 5
+    joker = GreedyJoker()
+
+    vouchers: Sequence[Voucher] = []
+    assert joker.cost(vouchers) == cost == joker._cost
+    assert joker.sell_value(vouchers) == 5 // 2
+
+    vouchers = [ClearanceSale()]
+    # 25% off
+    assert joker.cost(vouchers) == 3
+    assert joker.sell_value(vouchers) == 1
+
+    vouchers = [ClearanceSale(), Liquidation()]
+    # 50% off
+    assert joker.cost(vouchers) == 5 // 2
+    assert joker.sell_value(vouchers) == 1


### PR DESCRIPTION
Improve the HasCost protocol as discussed [here](https://github.com/maxsvetlik/balatro-gym/pull/50#discussion_r2105538330)

To avoid circular imports, I had to move the Voucher protocol to the voucher.py file.